### PR TITLE
Movendo seção de categorias para ficar logo abaixo do carrossel de Banner

### DIFF
--- a/GameSwapV1/src/pages/marketplace.html
+++ b/GameSwapV1/src/pages/marketplace.html
@@ -59,6 +59,29 @@
         </div>
     </section>
 
+    <!-- Seção de Categorias movida para aqui -->
+    <section class="categories">
+        <h2>Categorias Populares</h2>
+        <div class="categories-grid">
+            <div class="category-card">
+                <i class="fas fa-crosshairs"></i>
+                <h3>CS:GO</h3>
+            </div>
+            <div class="category-card">
+                <i class="fas fa-gamepad"></i>
+                <h3>Valorant</h3>
+            </div>
+            <div class="category-card">
+                <i class="fas fa-dragon"></i>
+                <h3>League of Legends</h3>
+            </div>
+            <div class="category-card">
+                <i class="fas fa-ghost"></i>
+                <h3>Fortnite</h3>
+            </div>
+        </div>
+    </section>
+
     <main>
         <div class="main-content">
         
@@ -248,27 +271,6 @@
             </div>
         </div>
     </main>
-    <section class="categories">
-        <h2>Categorias Populares</h2>
-        <div class="categories-grid">
-            <div class="category-card">
-                <i class="fas fa-crosshairs"></i>
-                <h3>CS:GO</h3>
-            </div>
-            <div class="category-card">
-                <i class="fas fa-gamepad"></i>
-                <h3>Valorant</h3>
-            </div>
-            <div class="category-card">
-                <i class="fas fa-dragon"></i>
-                <h3>League of Legends</h3>
-            </div>
-            <div class="category-card">
-                <i class="fas fa-ghost"></i>
-                <h3>Fortnite</h3>
-            </div>
-        </div>
-    </section>
     
     <footer>
         <div class="security-info">


### PR DESCRIPTION
Foi movido a sessão de categorias que estava próximo do foot para o topo do marketplace para dar mais destaque e ficar um pouco mais profissional.

![image](https://github.com/user-attachments/assets/1e84eaba-d92c-4101-b9c3-7865fece5fe9)
